### PR TITLE
Copy libffmpegsumo.so

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -33,6 +33,7 @@ package() {
   install -D -m755 "Messenger"    "${pkgdir}/opt/MessengerForDesktop/Messenger"
   install -D -m644 "nw.pak"       "${pkgdir}/opt/MessengerForDesktop/nw.pak"
   install -D -m644 "icudtl.dat"   "${pkgdir}/opt/MessengerForDesktop/icudtl.dat"
+  install -D -m644 "libffmpegsumo.so"   "${pkgdir}/opt/MessengerForDesktop/libffmpegsumo.so"
 
   cd "${srcdir}/messengerfordesktop-git/assets-linux"
   install -D -m644 "${srcdir}/messengerfordesktop-git/assets-linux/messengerfordesktop.desktop" "${pkgdir}/usr/share/applications/messengerfordesktop.desktop"


### PR DESCRIPTION
Without this lib, if you enable desktop notifications on a fresh archlinux installation, Messenger will crash at incoming messages.

It works without this lib on any system with a package including libffmpegsumo.so installed. Like when chromium is installed. When chromium is not installed -> crash.