### PR TITLE
This package conflicts with messengerfordesktop

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@ pkgdesc="Beautiful desktop client for Facebook Messenger. Sytten's fork"
 arch=('i686' 'x86_64')
 url="http://messengerfordesktop.com/"
 license=('MIT')
+conflicts=("messengerfordesktop")
 options=(!strip)
 depends=('gcc-libs' 'cairo' 'libxtst' 'alsa-lib' 'gtk2' 'gconf' 'libnotify' 'fontconfig' 'nss' 'xorg-xprop' 'xorg-xwininfo')
 makedepends=('git' 'gulp' 'npm')


### PR DESCRIPTION
The PR adds a `conflicts=("messengerfordesktop")` line that'll require the user to remove the `messengerfordesktop` package before installing `messengerfordesktop-git` (they have conflicting files and can't be installed at once anyway, this just makes it fail earlier with an option to remove it before installing).